### PR TITLE
PGP-428: Add made with Playpass banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@
                 <button name="back">Back</button>
             </p>
             <div id="abDebug"></div>
-            <a class="fork-ribbon" href="https://github.com/playpassgames/playpass-game-template" target="_blank">Made with Playpass</a>
+            <a class="fork-ribbon" href="https://playpass.games/" target="_blank">Made with Playpass</a>
         </div>
     </screen-router>
 

--- a/index.html
+++ b/index.html
@@ -243,6 +243,7 @@
                 <button name="back">Back</button>
             </p>
             <div id="abDebug"></div>
+            <a class="fork-ribbon" href="https://github.com/playpassgames/playpass-game-template" target="_blank">Fork with Playpass</a>
         </div>
     </screen-router>
 

--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@
                 <button name="back">Back</button>
             </p>
             <div id="abDebug"></div>
-            <a class="fork-ribbon" href="https://github.com/playpassgames/playpass-game-template" target="_blank">Fork with Playpass</a>
+            <a class="fork-ribbon" href="https://github.com/playpassgames/playpass-game-template" target="_blank">Made with Playpass</a>
         </div>
     </screen-router>
 


### PR DESCRIPTION
Before, there was no banner:
<img width="392" alt="Screen Shot 2022-08-09 at 5 45 52 PM" src="https://user-images.githubusercontent.com/17373817/183774619-49d63056-87ed-4c6f-896b-513be3b4022c.png">


Now, there is a banner:
<img width="392" alt="Screen Shot 2022-08-09 at 5 45 40 PM" src="https://user-images.githubusercontent.com/17373817/183774629-5db64b6c-e926-4214-8928-cdccfbe5b163.png">


